### PR TITLE
new default behavior when creating a powerplant: inverter kva rating …

### DIFF
--- a/plantpredict/inverter.py
+++ b/plantpredict/inverter.py
@@ -30,7 +30,7 @@ class Inverter(PlantPredictEntity):
 
     @handle_refused_connection
     @handle_error_response
-    def change_inverter_status(self, new_status, note=""):
+    def change_status(self, new_status, note=""):
         """
 
         :param new_status:
@@ -47,4 +47,22 @@ class Inverter(PlantPredictEntity):
                 "status": new_status,
                 "note": note
             }]
+        )
+
+    @handle_refused_connection
+    @handle_error_response
+    def get_kva(self, elevation, temperature, use_cooling_temp):
+        """
+        Uses the given elevation and temperature to interpolate a kVa rating from the inverter's kVa curves.
+
+        :param float elevation: Elevation at which to evaluate the inverter kVa rating - units :py:data:`[m]`.
+        :param float temperature: Temperature at which to evaluate the inverter kVa rating - units :py:data:`[deg-C]`.
+        :param bool use_cooling_temp: Determines if the calculation should use the plant design cooling temperature (
+                                      at 99.6 degrees).
+        :return: # TODO after new API response is implemented
+        """
+        return requests.get(
+            url=self.api.base_url + "/Inverter/{}/kVa".format(self.id),
+            headers={"Authorization": "Bearer " + self.api.access_token},
+            params={"elevation": elevation, "temperature": temperature, "useCoolingTemp": use_cooling_temp}
         )

--- a/plantpredict/utilities.py
+++ b/plantpredict/utilities.py
@@ -30,10 +30,10 @@ MANUAL_KEY_FIXES = {
         "p_o_a": "poa",
         "back_tracking": "backtracking",
         "back_side": "backside",
-        "transformerkva": "transformer_kva",
+        "k_v_a": "kva",
+        "transformerkva_rating": "transformer_kva_rating",
         "inverterkva": "inverter_kva",
         "usek_v_a": "use_kva_",
-        "k_v_a": "kva",
         "m_v": "mv",
         "e_s_s": "ess",
         "k_w": "_kw",
@@ -68,7 +68,10 @@ MANUAL_KEY_FIXES = {
         "cool996": "cool_996",
         "heat996": "heat_996",
         "max50_year": "max_50_year",
-        "min50_year": "min_50_year"
+        "min50_year": "min_50_year",
+        "p_q": "pq",
+        "kvacurves": "kva_curves",
+        "k_va": "kva"
     },
     "snake_to_camel": {
         "powerplant": "powerPlant",

--- a/tests/mocked_requests.py
+++ b/tests/mocked_requests.py
@@ -314,6 +314,20 @@ def mocked_requests_get(*args, **kwargs):
             status_code=200
         )
 
+    elif kwargs['url'] == "https://api.plantpredict.com/Inverter/808/kVa" and kwargs['params'] == {
+        'elevation': 1000, 'temperature': 20.0, 'useCoolingTemp': True
+    }:
+        return MockResponse(
+            json_data={'kva': 700.0},
+            status_code=200
+        )
+
+    elif kwargs['url'] == "https://api.plantpredict.com/Inverter/808/":
+        return MockResponse(
+            json_data={'power_rated': 600.0},
+            status_code=200
+        )
+
     return MockResponse(None, 404)
 
 

--- a/tests/plantpredict_unit_test_case.py
+++ b/tests/plantpredict_unit_test_case.py
@@ -5,6 +5,7 @@ from plantpredict.prediction import Prediction
 from plantpredict.module import Module
 from plantpredict.project import Project
 from plantpredict.ashrae import ASHRAE
+from plantpredict.powerplant import PowerPlant
 
 
 class PlantPredictUnitTestCase(unittest.TestCase):

--- a/tests/test_inverter.py
+++ b/tests/test_inverter.py
@@ -1,8 +1,9 @@
 import mock
 import unittest
+import json
 
 from plantpredict.inverter import Inverter
-from tests import plantpredict_unit_test_case
+from tests import plantpredict_unit_test_case, mocked_requests
 
 
 class TestInverter(plantpredict_unit_test_case.PlantPredictUnitTestCase):
@@ -41,6 +42,14 @@ class TestInverter(plantpredict_unit_test_case.PlantPredictUnitTestCase):
         inverter.update()
         self.assertEqual(inverter.update_url_suffix, "/Inverter")
         self.assertTrue(mocked_update.called)
+
+    @mock.patch('plantpredict.inverter.requests.get', new=mocked_requests.mocked_requests_get)
+    def test_get_kva(self):
+        self._make_mocked_api()
+        inverter = Inverter(api=self.mocked_api, id=808)
+        response = inverter.get_kva(elevation=1000, temperature=20, use_cooling_temp=True)
+
+        self.assertEqual(json.loads(response.content)['kva'], 700.0)
 
 
 if __name__ == '__main__':

--- a/tests/test_powerplant.py
+++ b/tests/test_powerplant.py
@@ -158,11 +158,44 @@ class TestPowerPlant(plantpredict_unit_test_case.PlantPredictUnitTestCase):
             "description": "testing"
         })
 
-    def test_add_inverter(self):
+    def test_add_array_no_match_total_inverter_kva(self):
         self._make_mocked_api()
         self.powerplant = PowerPlant(api=self.mocked_api, project_id=7, prediction_id=77)
         self._init_powerplant_structure()
-        inverter_name = self.powerplant.add_inverter(block_name=1, array_name=1, inverter_id=123, setpoint_kw=800)
+        array_name = self.powerplant.add_array(
+            block_name=1,
+            description="testing",
+            match_total_inverter_kva=False,
+            transformer_kva_rating=700.0
+        )
+
+        self.assertEqual(len(self.powerplant.blocks[0]["arrays"]), 2)
+        self.assertEqual(array_name, 2)
+        self.assertEqual(self.powerplant.blocks[0]["arrays"][1], {
+            "name": 2,
+            "repeater": 1,
+            "ac_collection_loss": 1,
+            "das_load": 800,
+            "cooling_load": 0,
+            "additional_losses": 0,
+            "transformer_enabled": True,
+            "match_total_inverter_kva": False,
+            "transformer_high_side_voltage": 34.5,
+            "transformer_no_load_loss": 0.2,
+            "transformer_full_load_loss": 0.7,
+            "inverters": [],
+            "description": "testing",
+            "transformer_kva_rating": 700.0
+        })
+
+    def test_add_inverter(self):
+        self._make_mocked_api()
+        self.powerplant = PowerPlant(api=self.mocked_api, project_id=7, prediction_id=77)
+        self.powerplant.use_cooling_temp = False
+        self._init_powerplant_structure()
+        inverter_name = self.powerplant.add_inverter(
+            block_name=1, array_name=1, inverter_id=123, setpoint_kw=800, kva_rating=650.0
+        )
 
         self.assertEqual(len(self.powerplant.blocks[0]["arrays"][0]["inverters"]), 2)
         self.assertEqual(inverter_name, "B")
@@ -172,6 +205,7 @@ class TestPowerPlant(plantpredict_unit_test_case.PlantPredictUnitTestCase):
             "inverter_id": 123,
             "setpoint_kw": 800,
             "power_factor": 1.0,
+            "kva_rating": 650.0,
             "dc_fields": []
         })
 
@@ -313,6 +347,7 @@ class TestPowerPlant(plantpredict_unit_test_case.PlantPredictUnitTestCase):
 
         self.assertEqual(self.powerplant.project_id, 7)
         self.assertEqual(self.powerplant.prediction_id, 77)
+        self.assertTrue(self.powerplant.use_cooling_temp)
         self.assertIsNone(self.powerplant.power_factor)
         self.assertIsNone(self.powerplant.blocks)
 


### PR DESCRIPTION
…will calculate based on the 99.6 degree cooling temperature of the plant's ASHRAE station, and will match at array level. added "get_kva" endpoint on Inverter class, which is used in this calculation upon calling add_inverter, documented methods, changed method "change_inverter_status" to "change_status", closes #78