### PR TITLE
changes input to add_dc_field from modules_wide to strings_wide, and …

### DIFF
--- a/tests/test_powerplant.py
+++ b/tests/test_powerplant.py
@@ -721,6 +721,11 @@ class TestPowerPlant(plantpredict_unit_test_case.PlantPredictUnitTestCase):
 
         self.assertEqual(post_height, 2.299038105676658)
 
+    def test_calculate_modules_wide(self):
+        modules_wide = PowerPlant._calculate_modules_wide(strings_wide=3, modules_wired_in_series=6)
+
+        self.assertEqual(modules_wide, 18)
+
     @mock.patch('plantpredict.powerplant.PowerPlant._calculate_default_post_height', mock_calculate_default_post_height)
     @mock.patch('plantpredict.plant_predict_entity.requests.get', new=mocked_requests.mocked_requests_get)
     @mock.patch('plantpredict.project.requests.get', new=mocked_requests.mocked_requests_get)


### PR DESCRIPTION
…adds method to calculate modules_wide from strings_wide (since strings_wide isn't a parameter persisted on the backend), closes #173